### PR TITLE
#59 | Change rootPath logic

### DIFF
--- a/internal/test/bootstrap.go
+++ b/internal/test/bootstrap.go
@@ -4,27 +4,24 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
-	"strings"
+	"runtime"
 	"testing"
 )
 
-const suffixPath = "idealista2messenger"
+const pathToRoot string = "../.."
 
 func init() {
 	testing.Init()
 	flag.Parse()
 
-	err := os.Chdir(getRootPath())
+	err := os.Chdir(rootPath())
 	if err != nil {
 		panic(err)
 	}
 }
 
-func getRootPath() string {
-	wd, _ := os.Getwd()
-	for flag.Lookup("test.v") != nil && !strings.HasSuffix(wd, suffixPath) {
-		wd = filepath.Dir(wd)
-	}
+func rootPath() string {
+	_, currFile, _, _ := runtime.Caller(0)
 
-	return wd
+	return filepath.Join(filepath.Dir(currFile), pathToRoot)
 }


### PR DESCRIPTION
Simplify `rootPath` logic and stop being dependant on the root directory name.