### PR TITLE
#79 | Update Renovate commit message schema

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "automerge": false,
   "rangeStrategy": "pin",
   "branchPrefix": "feature/renovate_",
-  "semanticCommitType": "RENOVATEBOT | ",
+  "commitMessagePrefix": "RENOVATEBOT | ",
   "labels": [
     "chore"
   ]


### PR DESCRIPTION
# What was changed

I've updated Renovate config

# Background

It was changed because current one was not working in a matter of commit message schema

# How it can be tested

CI

# Keep in mind that...

n/a
