### PR TITLE
#89 | Fix go version in test CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.19.x' ]
+        go-version: [ '1.21.x' ]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
# What was changed

I've updated the `go` version in the `CI` job

# Background

It was changed because it was wrong compared to the `go.mod`

# How it can be tested

CI

# Keep in mind that...

n/a
